### PR TITLE
Improved performance and compatibility

### DIFF
--- a/VSslnToCMake/CMProject.cs
+++ b/VSslnToCMake/CMProject.cs
@@ -171,11 +171,24 @@ namespace VSslnToCMake
         /// </summary>
         public string TargetName { get { return targetName; } }
 
+        private Dictionary<string, string> ImportLibs;
+
+        private ConfigurationTypes OutputType = ConfigurationTypes.typeUnknown;
         /// <summary>
         /// Type of output this project generates.
         /// </summary>
-        public ConfigurationTypes ConfigurationType { get { return vcCfgs[0].ConfigurationType; } }
- 
+        public ConfigurationTypes ConfigurationType
+        {
+            get
+            {
+                if (OutputType == ConfigurationTypes.typeUnknown)
+                {
+                    OutputType = vcCfgs[0].ConfigurationType;
+                }
+                return OutputType;
+            }
+        }
+
         public Project Project { get { return project; } }
 
         private Logger logger = new NullLogger();
@@ -231,9 +244,13 @@ namespace VSslnToCMake
 
         public Dictionary<string, string> getImportLibraries()
         {
-            return vcCfgs.ToDictionary(
-                x => solutionConfigurationNames[x.ConfigurationName],
-                x => x.Evaluate(x.ImportLibrary));
+            if (ImportLibs == null)
+            {
+                ImportLibs = vcCfgs.ToDictionary(
+                    x => solutionConfigurationNames[x.ConfigurationName],
+                    x => x.Evaluate(x.ImportLibrary));
+            }
+            return ImportLibs;
         }
 
         public bool Prepare()

--- a/VSslnToCMake/CMProject.cs
+++ b/VSslnToCMake/CMProject.cs
@@ -95,11 +95,11 @@ namespace VSslnToCMake
             // TODO デフォルト値の判定
             if (headerFilePath != DEFAULT_HEADER_FILE_PATH)
             {
-                option += string.Format($"\"{headerFilePath}\"");
+                option += string.Format($"\\\"{headerFilePath.Trim('\"').Replace("\\", "/")}\\\"");
             }
             if (pchFilePath != DEFAULT_PCH_FILE_PATH)
             {
-                option += string.Format($" /Fp\"{pchFilePath}\"");
+                option += string.Format($" /Fp\\\"{pchFilePath.Trim('\"').Replace("\\", "/")}\\\"");
             }
             return option;
         }

--- a/VSslnToCMake/CMProject.cs
+++ b/VSslnToCMake/CMProject.cs
@@ -867,7 +867,7 @@ namespace VSslnToCMake
                     GetSolutionConfigurationName,
                     kv => Environment.NewLine + "    " + 
                           string.Join(";" + Environment.NewLine + "    ",
-                                      kv.paths)));
+                                      kv.paths.Select(p => p.Replace("\\", "/")))));
             sb.AppendLine();
             sb.AppendLine(")");
 
@@ -1312,7 +1312,7 @@ namespace VSslnToCMake
                 sb.AppendLine($"  $<$<CONFIG:{solutionConfigurationNames[cfgName]}>:");
                 foreach (var path in paths)
                 {
-                    sb.Append($"    {option}{path}");
+                    sb.Append($"    {option}{path.Replace("\\", "/")}");
                     if (paths.IndexOf(path) == paths.Count - 1)
                     {
                         sb.AppendLine(">");


### PR DESCRIPTION
We had massive performance and memory issues when converting a solution with hundreds of projects.
Caching the configuration type and the imported libraries for each project helped a lot.

And we had issues with some of the paths. Since we need to use the cmake files on linux.
Converting the paths to use '/' as a path separator instead of '\' fixed the issue.
Particularly because '/' also works on windows. So it shouldn't be an issue regardless of the target OS.
